### PR TITLE
Initial tryout of setuptools setup.py installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ optional arguments:
 
 ```
 
+## Install
+
+Run installation through pip3:
+```
+pip3 install .
+```
+Since it is not yet distributed through pip packages yet this is the way, for now.
+The script can now be called as a module or be imported:
+
+```
+python3 -m activeDirectoryEnum 
+```
+
 ## Included attacks
 
 - [X] ASREPRoasting

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+import setuptools
+
+with open('README.md', 'r') as desc:
+    long_desc = desc.read()
+
+setuptools.setup(
+        name = 'ActiveDirectoryEnum',
+        version = '0.1.0',
+        author = 'Casper G. Nielsen',
+        author_email = 'whopsec@protonmail.com',
+        description = 'Enumerate Active Directory with standard vectors',
+        long_description = long_desc,
+        long_description_content_type = 'text/markdown',
+        url = 'https://github.com/CasperGN/ActiveDirectoryEnumeration',
+        packages = setuptools.find_packages(),
+        classifiers = [
+            'Programming Language :: Python :: 3',
+            'License :: OSI Approved :: MIT License',
+        ],
+        python_requires = '>=3.4',
+)


### PR DESCRIPTION
Tested through myself and @ninposec on two different distros. 
No errors on running:
```
~/ActiveDirectoryEnumeration# pip3 install .
Processing /root/ActiveDirectoryEnumeration
Building wheels for collected packages: ActiveDirectoryEnum
  Running setup.py bdist_wheel for ActiveDirectoryEnum ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-nfslgloa/wheels/89/cc/c2/3e101bcbccabbdb813a8ba2921f153f34451c14ab3905859c1
Successfully built ActiveDirectoryEnum
Installing collected packages: ActiveDirectoryEnum
Successfully installed ActiveDirectoryEnum-0.1.0
~/ActiveDirectoryEnumeration# python3 -m activeDirectoryEnum
usage: activeDirectoryEnum [-h] [-o OUT_FILE] [-s] [-smb] [-kp] [-bh] [-spn]
                           [--all]
                           dc user

        ___        __  _            ____  _                __                   ______                    
       /   | _____/ /_(_)   _____  / __ \(_)_______  _____/ /_____  _______  __/ ____/___  __  ______ ___ 
      / /| |/ ___/ __/ / | / / _ \/ / / / / ___/ _ \/ ___/ __/ __ \/ ___/ / / / __/ / __ \/ / / / __ `__ \
     / ___ / /__/ /_/ /| |/ /  __/ /_/ / / /  /  __/ /__/ /_/ /_/ / /  / /_/ / /___/ / / / /_/ / / / / / /
    /_/  |_\___/\__/_/ |___/\___/_____/_/_/   \___/\___/\__/\____/_/   \__, /_____/_/ /_/\__,_/_/ /_/ /_/ 
                                                                      /____/                             

|*----------------------------------------------------------------------------------------------------------*|

positional arguments:
  dc                    Hostname of the Domain Controller
  user                  Username of the domain user to query with. The
                        username has to be domain name as `user@domain.org`

optional arguments:
  -h, --help            show this help message and exit
  -o OUT_FILE, --out-file OUT_FILE
                        Path to output file. If no path, CWD is assumed
                        (default: None)
  -s, --secure          Try to estalish connection through LDAPS
  -smb, --smb           Force enumeration of SMB shares on all computer
                        objects fetched
  -kp, --kerberos_preauth
                        Attempt to gather users that does not require Kerberos
                        preauthentication
  -bh, --bloodhound     Output data in the format expected by BloodHound
  -spn                  Attempt to get all SPNs and perform Kerberoasting
  --all                 Run all checks

```