### PR TITLE
Sysvol search

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Crypto==1.4.1
 dnspython==1.16.0
 Flask==1.1.1
 future==0.18.2
-impacket==0.9.20
+impacket==0.9.21
 itsdangerous==1.1.0
 Jinja2==2.11.1
 ldap3==2.5.1


### PR DESCRIPTION
Searching sysvol for xml files containing `cpassword` and either `userName` or `runAs`.
For now the share is recursively searched untill all files are mapped, files are fetched (*nb:* including non-xml files as of now) and searched from attacker machine. The files have to be written during `SMB:Get` but will be removed after the run.
Negative run tested here:

```
~/ActiveDirectoryEnumeration# ./activeDirectoryEnum.py domain.local user@domain.local --all
[ OK ] Bound to LDAP server: domain.local
[ OK ] Got all Computer objects
[ OK ] Got all Person objects
[ OK ] Got all Group objects
[ OK ] Got all SPN objects
[ OK ] Got all ACL objects
[ OK ] Got all GPO objects
[ OK ] Got all Domains
[ OK ] Got all OUs
[ OK ] Found 0 clear text password
[ OK ] Wrote hosts with oldest OS to domain.local-oldest-OS
[ OK ] Found 0 cpasswords in GPOs on SYSVOL share
[ OK ] Generating BloodHound output - this may take time...
[ OK ] Found 1 account that does not require Kerberos preauthentication
[ OK ] Wrote all hashes to domain.local-jtr-hashes
[ OK ] Got 0 tickets for Kerberoasting
[ OK ] Found 1 dnsname
SMBConnection test: 100%|#####################################################|Time: 0:00:05

[ OK ] Searched 1 share and 1 with 4 subdirectories/files is browseable by user@domain.local
[ OK ] Wrote browseable shares to domain.local-open-smb
```