### PR TITLE
Created mvp-like testable regexes for somewhat validating that the do…

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ python3 -m activeDirectoryEnum
 - [X] Make `--all` flag that runs all checks
 - [X] Move smb enum to be the last check
 - [X] Make validation of password before proceeding with ldap connection + querries 
-- [ ] Create better validation of input format to ensure that domain flag is of `domain.local` type and user is `user@domain.local`
+- [X] Create better validation of input format to ensure that domain flag is of `domain.local` type and user is `user@domain.local`
 - [ ] Test for RPC and SMB Null sessions
 
 ## Collaboration

--- a/activeDirectoryEnum.py
+++ b/activeDirectoryEnum.py
@@ -565,6 +565,20 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    # If theres more than 4 sub'ed (test.test.domain.local) - tough luck sunny boy
+    domainRE = re.compile(r'^((?:[a-zA-Z0-9-.]+)?(?:[a-zA-Z0-9-.]+)?[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+)$')
+    userRE = re.compile(r'^([a-zA-Z0-9-]+@(?:[a-zA-Z0-9-.]+)?(?:[a-zA-Z0-9-.]+)?[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+)$')
+
+    domainMatch = domainRE.findall(args.dc)
+    userMatch = userRE.findall(args.user)
+
+    if not domainMatch:
+        print('[ ' + colored('NOT OK', 'red') +' ] Domain flag has to be in the form "domain.local"')
+        sys.exit(1)
+    if not userMatch:
+        print('[ ' + colored('NOT OK', 'red') +' ] User flag has to be in the form "user@domain.local"')
+        sys.exit(1)
+
     if args.all:
         args.smb = True
         args.kerberos_preauth = True


### PR DESCRIPTION
MVP test:
```
~/ActiveDirectoryEnumeration (input_val) $ ./activeDirectoryEnum.py domain.local user@domain.local
Password: 
...
~/ActiveDirectoryEnumeration (input_val) $ ./activeDirectoryEnum.py domain.local@ user@domain.local
[ NOT OK ] Domain flag has to be in the form "domain.local"
~/ActiveDirectoryEnumeration (input_val) $ ./activeDirectoryEnum.py domain.local user
[ NOT OK ] User flag has to be in the form "user@domain.local"
```

Most likely requires a couple of test runs to be sure it has any positive effect though.
I've limited the domain to 3 sub'ed, e.g. `dom1.dom2.dom3.local`.