### PR TITLE
Fix #22 - The regex is now changed to not accept '0-9' or '-' in last…

### DIFF
--- a/activeDirectoryEnum.py
+++ b/activeDirectoryEnum.py
@@ -768,7 +768,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # If theres more than 4 sub'ed (test.test.domain.local) - tough luck sunny boy
-    domainRE = re.compile(r'^((?:[a-zA-Z0-9-.]+)?(?:[a-zA-Z0-9-.]+)?[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+)$')
+    domainRE = re.compile(r'^((?:[a-zA-Z0-9-.]+)?(?:[a-zA-Z0-9-.]+)?[a-zA-Z0-9-]+\.[a-zA-Z]+)$')
     userRE = re.compile(r'^([a-zA-Z0-9-\.]+@(?:[a-zA-Z0-9-.]+)?(?:[a-zA-Z0-9-.]+)?[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+)$')
 
     domainMatch = domainRE.findall(args.dc)

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,10 @@ import setuptools
 with open('README.md', 'r') as desc:
     long_desc = desc.read()
 
+reqs = []
+with open('requirements.txt', 'r') as req:
+    reqs.append(req.read())
+
 setuptools.setup(
         name = 'ActiveDirectoryEnum',
         version = '0.3.0',
@@ -13,29 +17,7 @@ setuptools.setup(
         long_description_content_type = 'text/markdown',
         url = 'https://github.com/CasperGN/ActiveDirectoryEnumeration',
         packages = setuptools.find_packages(),
-        install_reqs = [
-            "cffi",
-            "Click",
-            "cryptography",
-            "Crypto",
-            "dnspython",
-            "Flask",
-            "future",
-            "impacket",
-            "itsdangerous",
-            "Jinja2",
-            "ldap3",
-            "ldapdomaindump",
-            "MarkupSafe",
-            "progressbar",
-            "pyasn1"
-            "pycparser",
-            "pycryptodomex",
-            "pyOpenSSL",
-            "six",
-            "termcolor",
-            "Werkzeug",
-        ],
+        install_requires = reqs, 
         classifiers = [
             'Programming Language :: Python :: 3',
             'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
… matchgroup. Setup.py is also fixed after last nights (late..) attempt at fixing

Test:
```
(issue_22) $ ./activeDirectoryEnum.py -u arksvc@cascade.local -o outputfile --no-creds 10.10.10.182
[ ERROR ] Domain flag has to be in the form "domain.local"
(issue_22) $ ./activeDirectoryEnum.py -u arksvc@cascade.local -o outputfile --no-creds cascade.local
[ INFO ] Attempting to get objects without credentials
...
```
