### PR TITLE
Fix call to AES.new (using bytes instead of str)

### DIFF
--- a/activeDirectoryEnum.py
+++ b/activeDirectoryEnum.py
@@ -323,7 +323,7 @@ class EnumAD():
                     unameRE = re.compile(r'userName|runAs=\"([ a-zA-Z0-9/\(\)-]+)\"')
 
                     # Prepare the ciphers based on MSDN article with key and IV
-                    cipher = AES.new(bytes.fromhex('4e9906e8fcb66cc9faf49310620ffee8f496e806cc057990209b09a433b66c1b'), AES.MODE_CBC, '\x00' * 16)
+                    cipher = AES.new(bytes.fromhex('4e9906e8fcb66cc9faf49310620ffee8f496e806cc057990209b09a433b66c1b'), AES.MODE_CBC, bytes.fromhex('00' * 16))
                 
                     # Since the first entry is the DC we dont want that
                     for item in paths[1:]:


### PR DESCRIPTION
Using python3.8 (OS: archlinux), I got this error:
```
[ .. ] Searching SYSVOL for cpasswords
Traceback (most recent call last):
  File "./activeDirectoryEnum.py", line 799, in <module>
    enumAD = EnumAD(args.dc, args.secure, file_to_write, args.smb, args.bloodhound, args.kerberos_preauth, args.spn, args.user)
  File "./activeDirectoryEnum.py", line 75, in __init__
    self.runWithoutCreds()
  File "./activeDirectoryEnum.py", line 122, in runWithoutCreds
    self.search()
  File "./activeDirectoryEnum.py", line 231, in search
    self.enumForCreds(self.deletedUsers)
  File "./activeDirectoryEnum.py", line 693, in enumForCreds
    self.runWithCreds()
  File "./activeDirectoryEnum.py", line 90, in runWithCreds
    self.checkSYSVOL()
  File "./activeDirectoryEnum.py", line 326, in checkSYSVOL
    cipher = AES.new(bytes.fromhex('4e9906e8fcb66cc9faf49310620ffee8f496e806cc057990209b09a433b66c1b'), AES.MODE_CBC, '\x00' * 16)
  File "/usr/lib/python3.8/site-packages/Crypto/Cipher/AES.py", line 232, in new
    return _create_cipher(sys.modules[__name__], key, mode, *args, **kwargs)
  File "/usr/lib/python3.8/site-packages/Crypto/Cipher/__init__.py", line 79, in _create_cipher
    return modes[mode](factory, **kwargs)
  File "/usr/lib/python3.8/site-packages/Crypto/Cipher/_mode_cbc.py", line 293, in _create_cbc_cipher
    return CbcMode(cipher_state, iv)
  File "/usr/lib/python3.8/site-packages/Crypto/Cipher/_mode_cbc.py", line 97, in __init__
    c_uint8_ptr(iv),
  File "/usr/lib/python3.8/site-packages/Crypto/Util/_raw_api.py", line 144, in c_uint8_ptr
    raise TypeError("Object type %s cannot be passed to C code" % type(data))
TypeError: Object type <class 'str'> cannot be passed to C code
```
The error comes from : ``'\x00' * 16`` which returns a str instead of bytes required by the AES.new.

You didn't got this error ?